### PR TITLE
refactor: add svelte-ignore a11y comment

### DIFF
--- a/src/components/inputs/EditField.svelte
+++ b/src/components/inputs/EditField.svelte
@@ -17,10 +17,12 @@
   <div class="rounded-sm border border-gray-100 flex items-center px-2">
     <slot name="type"></slot>
   </div>
+  <!-- svelte-ignore a11y-label-has-associated-control -->
   <label class="flex flex-col flex-1">
     <span class="font-semibold text-xs">Label</span>
     <slot name="label"></slot>
   </label>
+  <!-- svelte-ignore a11y-label-has-associated-control -->
   <div class="field">
     <label class="flex flex-col flex-1">
       <span class="font-semibold text-xs">ID</span>

--- a/src/components/inputs/GenericField.svelte
+++ b/src/components/inputs/GenericField.svelte
@@ -23,6 +23,7 @@
 <div class="field" class:is-horizontal={leftlabel}>
   {#if leftlabel}
     <div class="field-label is-normal">
+      <!-- svelte-ignore a11y-label-has-associated-control -->
       <label class="label" {title}>
         {leftlabel}
         {#if info}

--- a/src/components/inputs/TextInput.svelte
+++ b/src/components/inputs/TextInput.svelte
@@ -13,6 +13,7 @@
   // Note: Svelte seems to have some issues with two-way binding, so if this is acting up it's probably that
 </script>
 
+<!-- svelte-ignore a11y-label-has-associated-control -->
 <label class="flex flex-col items-start {variants}" {id}>
   {#if label}
      <span class="text-base mb-1 text-gray-900 font-semibold">{label}</span>


### PR DESCRIPTION
## Description
Changes to prevent warnings on compilation.
`svelte: A11y: A form label must be associated with a control.`

## Related Issue
#17 
